### PR TITLE
feat: add multi-scene support for slides (fixes #74)

### DIFF
--- a/autoslide/pipeline/annotation/initial_annotation.py
+++ b/autoslide/pipeline/annotation/initial_annotation.py
@@ -93,172 +93,199 @@ def main():
             print(f"Processing file {i+1}/{len(file_list)}: {file_basename}")
             print(f"  Full path: {data_path}")
 
-        slide_handler = utils.slide_handler(data_path)
-        scene = slide_handler.scene
-        image_rect = np.array(scene.rect) // down_sample
-        image = scene.read_block(size=image_rect[2:])
-
+        # First, check how many scenes are in the slide
+        temp_handler = utils.slide_handler(data_path, scene_index=0)
+        num_scenes = temp_handler.num_scenes
+        
         if verbose:
-            print(
-                f"  Image loaded - Original size: {scene.rect[2:4]}, Downsampled size: {image_rect[2:4]}")
+            print(f"  Number of scenes in slide: {num_scenes}")
+        
+        # Loop over all scenes
+        for scene_idx in range(num_scenes):
+            if verbose:
+                print(f"  Processing scene {scene_idx + 1}/{num_scenes}")
+            
+            slide_handler = utils.slide_handler(data_path, scene_index=scene_idx)
+            scene = slide_handler.scene
+            image_rect = np.array(scene.rect) // down_sample
+            image = scene.read_block(size=image_rect[2:])
 
-        ############################################################
-
-        if verbose:
-            print(f"  Generating threshold mask...")
-        threshold_mask = utils.get_threshold_mask(scene, down_sample=down_sample)
-
-        if verbose:
-            print(f"  Applying morphological dilation...")
-        dilation_kern = np.ones((dilation_kern_size, dilation_kern_size))
-        dilated_mask = dilation(threshold_mask, footprint=dilation_kern)
-
-        if verbose:
-            print(f"  Labeling connected components...")
-        label_image = label(dilated_mask)
-        regions = regionprops(label_image)
-        image_label_overlay = label2rgb(
-            label_image, image=dilated_mask, bg_label=0)
-
-        if verbose:
-            print(f"  Found {len(regions)} regions total")
-
-        wanted_feature_names = [
-            'label',
-            'area',
-            'eccentricity',
-            'axis_major_length',
-            'axis_minor_length',
-            'eccentricity',
-            'solidity',
-            'centroid',
-        ]
-
-        if verbose:
-            print(
-                f"  Extracting region features: {', '.join(wanted_feature_names)}")
-
-        wanted_features = [
-            [getattr(region, feature_name) for region in regions]
-            for feature_name in wanted_feature_names
-        ]
-
-        region_frame = pd.DataFrame(
-            {feature_name: feature for feature_name, feature in
-             zip(wanted_feature_names, wanted_features)}
-        )
-
-        region_frame.sort_values('label', ascending=True, inplace=True)
-        wanted_regions_frame = region_frame[region_frame.area > area_threshold]
-        wanted_regions = wanted_regions_frame.label.values
-
-        if verbose:
-            print(
-                f"  Filtered to {len(wanted_regions)} regions above area threshold ({area_threshold})")
-            if len(wanted_regions) > 0:
+            if verbose:
                 print(
-                    f"  Region areas: min={wanted_regions_frame.area.min():.0f}, max={wanted_regions_frame.area.max():.0f}, mean={wanted_regions_frame.area.mean():.0f}")
+                    f"    Image loaded - Original size: {scene.rect[2:4]}, Downsampled size: {image_rect[2:4]}")
 
-        # Output wanted_regions_frame to be annotated manually
-        wanted_regions_frame['tissue_type'] = np.nan
-        wanted_regions_frame['tissue_num'] = np.nan
+            ############################################################
+            
+            # Create scene-specific basename for multi-scene slides
+            if num_scenes > 1:
+                scene_basename = file_basename.replace('.svs', f'_scene{scene_idx}.svs')
+            else:
+                scene_basename = file_basename
 
-        csv_path = os.path.join(
-            annot_dir, file_basename.replace('.svs', '.csv'))
-        wanted_regions_frame.to_csv(csv_path, index=False)
+            if verbose:
+                print(f"    Generating threshold mask...")
+            threshold_mask = utils.get_threshold_mask(scene, down_sample=down_sample)
 
+            if verbose:
+                print(f"    Applying morphological dilation...")
+            dilation_kern = np.ones((dilation_kern_size, dilation_kern_size))
+            dilated_mask = dilation(threshold_mask, footprint=dilation_kern)
+
+            if verbose:
+                print(f"    Labeling connected components...")
+            label_image = label(dilated_mask)
+            regions = regionprops(label_image)
+            image_label_overlay = label2rgb(
+                label_image, image=dilated_mask, bg_label=0)
+
+            if verbose:
+                print(f"    Found {len(regions)} regions total")
+
+            wanted_feature_names = [
+                'label',
+                'area',
+                'eccentricity',
+                'axis_major_length',
+                'axis_minor_length',
+                'eccentricity',
+                'solidity',
+                'centroid',
+            ]
+
+            if verbose:
+                print(
+                    f"    Extracting region features: {', '.join(wanted_feature_names)}")
+
+            wanted_features = [
+                [getattr(region, feature_name) for region in regions]
+                for feature_name in wanted_feature_names
+            ]
+
+            region_frame = pd.DataFrame(
+                {feature_name: feature for feature_name, feature in
+                 zip(wanted_feature_names, wanted_features)}
+            )
+
+            region_frame.sort_values('label', ascending=True, inplace=True)
+            wanted_regions_frame = region_frame[region_frame.area > area_threshold]
+            wanted_regions = wanted_regions_frame.label.values
+
+            if verbose:
+                print(
+                    f"    Filtered to {len(wanted_regions)} regions above area threshold ({area_threshold})")
+                if len(wanted_regions) > 0:
+                    print(
+                        f"    Region areas: min={wanted_regions_frame.area.min():.0f}, max={wanted_regions_frame.area.max():.0f}, mean={wanted_regions_frame.area.mean():.0f}")
+
+            # Output wanted_regions_frame to be annotated manually
+            wanted_regions_frame['tissue_type'] = np.nan
+            wanted_regions_frame['tissue_num'] = np.nan
+
+            csv_path = os.path.join(
+                annot_dir, scene_basename.replace('.svs', '.csv'))
+            wanted_regions_frame.to_csv(csv_path, index=False)
+
+            if verbose:
+                print(f"    Saved region metadata to: {csv_path}")
+
+            # Drop regions that are not wanted
+            fin_label_image = label_image.copy()
+            dropped_count = 0
+            for i in region_frame.label.values:
+                if i not in wanted_regions:
+                    fin_label_image[fin_label_image == i] = 0
+                    dropped_count += 1
+
+            if verbose:
+                print(f"    Dropped {dropped_count} regions below area threshold")
+
+            # Write out image with regions labelled
+            npy_path = os.path.join(
+                annot_dir, scene_basename.replace('.svs', '.npy'))
+            np.save(npy_path, fin_label_image)
+
+            if verbose:
+                print(f"    Saved label image to: {npy_path}")
+
+            if verbose:
+                print(f"    Generating visualization plots...")
+
+            image_label_overlay = label2rgb(fin_label_image,
+                                            image=fin_label_image > 0,
+                                            bg_label=0)
+
+            filled_binary = binary_fill_holes(fin_label_image > 0)*1
+
+            gradient_image = gradient(filled_binary, np.ones((10, 10)))
+            grad_inds = np.where(gradient_image > 0)
+
+            if verbose:
+                print(f"    Creating 5-panel visualization plot...")
+
+            fig, ax = plt.subplots(1, 5,
+                                   sharex=True, sharey=True,
+                                   figsize=(20, 10)
+                                   )
+            ax[0].imshow(np.swapaxes(image, 0, 1))
+            ax[1].imshow(threshold_mask)
+            ax[2].imshow(dilated_mask)
+            ax[3].imshow(image_label_overlay)
+            ax[4].imshow(np.swapaxes(image, 0, 1))
+            ax[4].scatter(grad_inds[1], grad_inds[0],
+                          s=1, color='orange', alpha=0.7,
+                          label='Outline')
+            ax[0].set_title('Original')
+            ax[1].set_title('Threshold')
+            ax[2].set_title('Dilated')
+            ax[3].set_title('Labelled')
+            ax[4].set_title('Outline Overlay')
+            ax[4].legend()
+            # Add labels at the center of each region
+            for this_row in wanted_regions_frame.itertuples():
+                ax[3].text(this_row.centroid[1], this_row.centroid[0],
+                           this_row.label, color='r', fontsize=25,
+                           weight='bold')
+            fig.suptitle(f"{file_basename} - Scene {scene_idx}")
+            plt.tight_layout()
+
+            plot_path = os.path.join(
+                annot_dir, scene_basename.replace('.svs', '.png'))
+            fig.savefig(plot_path, bbox_inches='tight')
+            plt.close(fig)
+
+            if verbose:
+                print(f"    Saved visualization plot to: {plot_path}")
+
+            # Write out a json with:
+            # - file_basename
+            # - data_path
+            # - scene_index
+            # - num_scenes
+            # - fin_label_image path
+            # - wanted_regions_frame path
+
+            json_data = {
+                'file_basename': file_basename,
+                'scene_basename': scene_basename,
+                'data_path': data_path,
+                'scene_index': scene_idx,
+                'num_scenes': num_scenes,
+                'initial_mask_path': os.path.join(annot_dir, scene_basename.replace('.svs', '.npy')),
+                'wanted_regions_frame_path': os.path.join(annot_dir, scene_basename.replace('.svs', '.csv')),
+            }
+
+            json_path = os.path.join(
+                tracking_dir, scene_basename.replace('.svs', '.json'))
+            with open(json_path, 'w') as f:
+                json.dump(json_data, f, indent=4)
+
+            if verbose:
+                print(f"    Saved tracking JSON to: {json_path}")
+                print(f"    Completed processing scene {scene_idx + 1}/{num_scenes}")
+                print()
+        
         if verbose:
-            print(f"  Saved region metadata to: {csv_path}")
-
-        # Drop regions that are not wanted
-        fin_label_image = label_image.copy()
-        dropped_count = 0
-        for i in region_frame.label.values:
-            if i not in wanted_regions:
-                fin_label_image[fin_label_image == i] = 0
-                dropped_count += 1
-
-        if verbose:
-            print(f"  Dropped {dropped_count} regions below area threshold")
-
-        # Write out image with regions labelled
-        npy_path = os.path.join(
-            annot_dir, file_basename.replace('.svs', '.npy'))
-        np.save(npy_path, fin_label_image)
-
-        if verbose:
-            print(f"  Saved label image to: {npy_path}")
-
-        if verbose:
-            print(f"  Generating visualization plots...")
-
-        image_label_overlay = label2rgb(fin_label_image,
-                                        image=fin_label_image > 0,
-                                        bg_label=0)
-
-        filled_binary = binary_fill_holes(fin_label_image > 0)*1
-
-        gradient_image = gradient(filled_binary, np.ones((10, 10)))
-        grad_inds = np.where(gradient_image > 0)
-
-        if verbose:
-            print(f"  Creating 5-panel visualization plot...")
-
-        fig, ax = plt.subplots(1, 5,
-                               sharex=True, sharey=True,
-                               figsize=(20, 10)
-                               )
-        ax[0].imshow(np.swapaxes(image, 0, 1))
-        ax[1].imshow(threshold_mask)
-        ax[2].imshow(dilated_mask)
-        ax[3].imshow(image_label_overlay)
-        ax[4].imshow(np.swapaxes(image, 0, 1))
-        ax[4].scatter(grad_inds[1], grad_inds[0],
-                      s=1, color='orange', alpha=0.7,
-                      label='Outline')
-        ax[0].set_title('Original')
-        ax[1].set_title('Threshold')
-        ax[2].set_title('Dilated')
-        ax[3].set_title('Labelled')
-        ax[4].set_title('Outline Overlay')
-        ax[4].legend()
-        # Add labels at the center of each region
-        for this_row in wanted_regions_frame.itertuples():
-            ax[3].text(this_row.centroid[1], this_row.centroid[0],
-                       this_row.label, color='r', fontsize=25,
-                       weight='bold')
-        fig.suptitle(file_basename)
-        plt.tight_layout()
-
-        plot_path = os.path.join(
-            annot_dir, file_basename.replace('.svs', '.png'))
-        fig.savefig(plot_path, bbox_inches='tight')
-        plt.close(fig)
-
-        if verbose:
-            print(f"  Saved visualization plot to: {plot_path}")
-
-        # Write out a json with:
-        # - file_basename
-        # - data_path
-        # - fin_label_image path
-        # - wanted_regions_frame path
-
-        json_data = {
-            'file_basename': file_basename,
-            'data_path': data_path,
-            'initial_mask_path': os.path.join(annot_dir, file_basename.replace('.svs', '.npy')),
-            'wanted_regions_frame_path': os.path.join(annot_dir, file_basename.replace('.svs', '.csv')),
-        }
-
-        json_path = os.path.join(
-            tracking_dir, file_basename.replace('.svs', '.json'))
-        with open(json_path, 'w') as f:
-            json.dump(json_data, f, indent=4)
-
-        if verbose:
-            print(f"  Saved tracking JSON to: {json_path}")
-            print(f"  Completed processing {file_basename}")
+            print(f"  Completed processing all scenes for {file_basename}")
             print()
 
     if verbose:

--- a/autoslide/pipeline/suggest_regions.py
+++ b/autoslide/pipeline/suggest_regions.py
@@ -165,7 +165,12 @@ def main():
                 print(f"Opening slide: {data_path}")
             
             # Use slide_handler for consistent slide opening
-            slide_metadata = utils.slide_handler(data_path)
+            # Get scene_index from JSON if available (for multi-scene slides)
+            scene_index = this_json.get('scene_index', 0)
+            if verbose and 'scene_index' in this_json:
+                print(f"Using scene index: {scene_index}")
+            
+            slide_metadata = utils.slide_handler(data_path, scene_index=scene_index)
             slide = slide_metadata.slide
             scene = slide_metadata.scene
             resolution = scene.resolution[0]  # meters / pixel

--- a/autoslide/pipeline/utils.py
+++ b/autoslide/pipeline/utils.py
@@ -19,8 +19,10 @@ from tqdm import tqdm, trange
 class slide_handler():
     def __init__(
             self,
-            slide_path):
+            slide_path,
+            scene_index=0):
         self.slide_path = slide_path
+        self.scene_index = scene_index
         
         # Automatically detect driver based on file extension
         file_ext = os.path.splitext(slide_path)[1].lower()
@@ -33,7 +35,8 @@ class slide_handler():
             driver = 'SVS'
         
         self.slide = slideio.open_slide(slide_path, driver)
-        self.scene = self.slide.get_scene(0)
+        self.num_scenes = self.slide.num_scenes
+        self.scene = self.slide.get_scene(scene_index)
         self.metadata_str = self.slide.raw_metadata
         self.metadata = {}
         for item in self.metadata_str.split('|'):

--- a/autoslide/utils/get_section_from_hash.py
+++ b/autoslide/utils/get_section_from_hash.py
@@ -47,7 +47,9 @@ def get_section_from_hash(hash_value, df, down_sample=1):
     section_details = get_section_details_from_hash(hash_value, df)
 
     section_bounds = literal_eval(section_details['section_bounds'])
-    slide_handler = utils.slide_handler(section_details['data_path'])
+    # Get scene_index if available (for multi-scene slides)
+    scene_index = section_details.get('scene_index', 0)
+    slide_handler = utils.slide_handler(section_details['data_path'], scene_index=scene_index)
     scene = slide_handler.scene
 
     section = utils.get_section(scene, section_bounds,
@@ -67,6 +69,7 @@ def load_tracking_data(tracking_dir):
         suggested_regions_paths: list, paths to suggested regions CSV files.
         basename_list: list, basenames of the files.
         data_path_list: list, paths to the data files.
+        scene_index_list: list, scene indices for multi-scene slides.
     """
     json_path_list = glob(os.path.join(tracking_dir, '*.json'))
     json_list = [json.load(open(x, 'r')) for x in json_path_list]
@@ -74,20 +77,22 @@ def load_tracking_data(tracking_dir):
     suggested_regions_paths = []
     basename_list = []
     data_path_list = []
+    scene_index_list = []
 
     for x in json_list:
         try:
             suggested_regions_paths.append(x['suggested_regions_frame_path'])
             basename_list.append(x['file_basename'].split('.')[0])
             data_path_list.append(x['data_path'])
+            scene_index_list.append(x.get('scene_index', 0))
         except KeyError:
             print(f"KeyError in {x['file_basename']}, skipping...")
             continue
 
-    return suggested_regions_paths, basename_list, data_path_list
+    return suggested_regions_paths, basename_list, data_path_list, scene_index_list
 
 
-def load_suggested_regions(suggested_regions_paths, basename_list, data_path_list):
+def load_suggested_regions(suggested_regions_paths, basename_list, data_path_list, scene_index_list):
     """
     Load suggested regions from CSV files.
 
@@ -95,6 +100,7 @@ def load_suggested_regions(suggested_regions_paths, basename_list, data_path_lis
         suggested_regions_paths: list, paths to suggested regions CSV files.
         basename_list: list, basenames of the files.
         data_path_list: list, paths to the data files.
+        scene_index_list: list, scene indices for multi-scene slides.
 
     Returns:
         final_df: pd.DataFrame, concatenated dataframe of all suggested regions.
@@ -105,10 +111,12 @@ def load_suggested_regions(suggested_regions_paths, basename_list, data_path_lis
         path = suggested_regions_paths[i]
         basename = basename_list[i]
         data_path = data_path_list[i]
+        scene_index = scene_index_list[i]
         try:
             df = pd.read_csv(path)
             df['basename'] = basename
             df['data_path'] = data_path
+            df['scene_index'] = scene_index
             suggested_regions_list.append(df)
         except FileNotFoundError:
             print(f"FileNotFoundError: {path}, skipping...")
@@ -130,7 +138,9 @@ def visualize_section(section, utils):
     """
     section_bounds = literal_eval(section['section_bounds'])
 
-    slide_handler = utils.slide_handler(section['data_path'])
+    # Get scene_index if available (for multi-scene slides)
+    scene_index = section.get('scene_index', 0)
+    slide_handler = utils.slide_handler(section['data_path'], scene_index=scene_index)
     scene = slide_handler.scene
 
     fig, ax = utils.visualize_sections(
@@ -157,12 +167,12 @@ def main():
     tracking_dir = config['tracking_dir']
 
     # Load tracking data
-    suggested_regions_paths, basename_list, data_path_list = load_tracking_data(
+    suggested_regions_paths, basename_list, data_path_list, scene_index_list = load_tracking_data(
         tracking_dir)
 
     # Load suggested regions
     final_df = load_suggested_regions(
-        suggested_regions_paths, basename_list, data_path_list)
+        suggested_regions_paths, basename_list, data_path_list, scene_index_list)
 
     # Test with a specific hash
     test_hash = '0cb8cf88e2d3c22d'


### PR DESCRIPTION
## Summary
This PR addresses issue #74 by implementing support for slides with multiple scenes.

## Changes Made

### Core Changes
- **slide_handler class** (`autoslide/pipeline/utils.py`):
  - Added `scene_index` parameter (default: 0) to allow selecting specific scenes
  - Added `num_scenes` property to track total number of scenes in a slide
  - Maintains backward compatibility with existing code

### Pipeline Updates
- **initial_annotation.py**:
  - Now detects and loops over all scenes in a slide
  - Each scene is treated as a separate pseudo-slide with unique naming (e.g., `filename_scene0.svs`, `filename_scene1.svs`)
  - Scene metadata (scene_index, num_scenes) is stored in tracking JSON files
  - Visualization plots include scene index in titles

- **suggest_regions.py**:
  - Updated to read scene_index from tracking JSON files
  - Properly handles multi-scene slides by using the correct scene index

- **get_section_from_hash.py**:
  - Updated all functions to support scene_index parameter
  - Modified `load_tracking_data()` to return scene indices
  - Updated `load_suggested_regions()` to include scene_index in dataframes
  - Functions now properly retrieve sections from the correct scene

## Implementation Details

The solution follows the approach suggested in issue #74:
1. Loop over scenes during initial annotation
2. Treat each scene as a separate "pseudo-slide" after initial annotation
3. Track scene information in metadata for downstream processing

## Backward Compatibility

All changes maintain backward compatibility:
- `scene_index` parameter defaults to 0 (first scene)
- Existing single-scene slides work without modification
- Multi-scene slides are automatically detected and processed

## Testing

- All modified Python files compile successfully without syntax errors
- Changes follow existing code patterns and conventions

Fixes #74
