### PR TITLE
Add animal_number column to annotations and fibrosis results

### DIFF
--- a/autoslide/src/pipeline/annotation/initial_annotation.py
+++ b/autoslide/src/pipeline/annotation/initial_annotation.py
@@ -19,6 +19,7 @@ import pylab as plt
 import cv2 as cv
 import numpy as np
 import argparse
+import re
 from pprint import pprint
 from glob import glob
 import pandas as pd
@@ -191,6 +192,12 @@ def main():
             wanted_regions_frame['tissue_type'] = np.nan
             wanted_regions_frame['tissue_num'] = np.nan
 
+            # Extract animal number from filename (5-digit number)
+            animal_number_match = re.search(r'(\d{5})', file_basename)
+            animal_number = animal_number_match.group(
+                1) if animal_number_match else None
+            wanted_regions_frame['animal_number'] = animal_number
+
             csv_path = os.path.join(
                 annot_dir, f"{scene_basename_stem}.csv")
             wanted_regions_frame.to_csv(csv_path, index=False)
@@ -274,6 +281,12 @@ def main():
             # - num_scenes
             # - fin_label_image path
             # - wanted_regions_frame path
+            # - animal_number (extracted from filename)
+
+            # Extract animal number from filename (5-digit number)
+            animal_number_match = re.search(r'(\d{5})', file_basename)
+            animal_number = animal_number_match.group(
+                1) if animal_number_match else None
 
             json_data = {
                 'file_basename': file_basename,
@@ -281,6 +294,7 @@ def main():
                 'data_path': data_path,
                 'scene_index': scene_idx,
                 'num_scenes': num_scenes,
+                'animal_number': animal_number,
                 'initial_mask_path': os.path.join(annot_dir, f"{scene_basename_stem}.npy"),
                 'wanted_regions_frame_path': os.path.join(annot_dir, f"{scene_basename_stem}.csv"),
             }

--- a/autoslide/src/pipeline/suggest_regions.py
+++ b/autoslide/src/pipeline/suggest_regions.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 import hashlib
 import argparse
 import time
+import re
 
 # Import utilities directly
 from autoslide.src.pipeline import utils
@@ -304,7 +305,13 @@ def main():
 
             section_frame['section_labels'] = section_labels
 
+            # Add animal number from tracking JSON
+            animal_number = this_json.get('animal_number', None)
+            section_frame['animal_number'] = animal_number
+            section_frame['file_basename'] = this_json['file_basename']
+
             if verbose:
+                print(f"Animal number: {animal_number}")
                 print("Generating section hashes...")
             # Generate unique identifiers based on section properties only (not row index)
             # Hash is based on: scene name, section bounds, label value, and tissue type


### PR DESCRIPTION
## Summary
This PR adds an `animal_number` column to the annotation CSVs and final fibrosis quantification results, enabling downstream analyses to group and filter data by animal.

## Changes
- **initial_annotation.py**: Extracts 5-digit animal number from slide filename using regex pattern `(\d{5})`, adds to initial annotation CSV and tracking JSON
- **suggest_regions.py**: Reads animal number from tracking JSON, propagates to section_frame CSV along with file_basename
- **calc_fibrosis.py**: Loads animal number mapping from section_frame files, adds animal_number column to final fibrosis quantification results CSV

## Implementation Details
The animal number is extracted from slide filenames following the pattern:
```
<STAIN_TYPE> <SAMPLE_INFO> <ANIMAL_NUMBER>.svs
Example: TRI 142B-155 146A-159 38717.svs → animal_number: 38717
```

The animal number flows through the pipeline:
1. Initial annotation → tracking JSON + initial CSV
2. Suggest regions → section_frame CSV
3. Fibrosis calculation → final results CSV

## Testing
- Syntax validation passed for all modified files
- Animal number extraction handles missing patterns gracefully (returns None)

Closes #110